### PR TITLE
Warn about optional IDF comments instead of error

### DIFF
--- a/checks/atlas_checker.py
+++ b/checks/atlas_checker.py
@@ -109,6 +109,10 @@ class AtlasMAGETABChecker:
             if comment.lower() not in self.idf_values:
                 logger.error("Comment \"{}\" not found in IDF. Required for Single Cell Atlas.".format(comment))
                 self.errors.add("SC-E01")
+        optional_comments = get_controlled_vocabulary("optional_singlecell_idf_comments", "atlas")
+        for comment in optional_comments:
+            if comment.lower() not in self.idf_values:
+                logger.warn("Comment \"{}\" not found in IDF. This is optional.".format(comment))
 
         # Atlas IDF comment value checks
         for k, attribs in self.idf.items():

--- a/config/atlas_validation_config.json
+++ b/config/atlas_validation_config.json
@@ -28,10 +28,12 @@
   ],
   "required_singlecell_idf_comments": [
     "EACurator",
-    "EAAdditionalAttributes",
-    "EAExpectedClusters",
     "EAExperimentType",
     "AEExperimentType"
+  ],
+  "optional_singlecell_idf_comments": [
+    "EAAdditionalAttributes",
+    "EAExpectedClusters"
   ],
   "required_singlecell_sdrf_fields": [
     "material type",


### PR DESCRIPTION
Some of the IDF comments are now optional and are not required by the data pipeline any more, e.g. the number of expected clusters is now automatically estimated. 
This changes moves these comments from a check that generates an error to a check that gives a warning (as a reminder for the curator). 