### PR TITLE
Report duplicates in the IDF field list

### DIFF
--- a/checks/atlas_checker.py
+++ b/checks/atlas_checker.py
@@ -109,6 +109,9 @@ class AtlasMAGETABChecker:
             if comment.lower() not in self.idf_values:
                 logger.error("Comment \"{}\" not found in IDF. Required for Single Cell Atlas.".format(comment))
                 self.errors.add("SC-E01")
+        if self.idf.get("duplicates"):
+            logger.error("Detected duplicated IDF field \"{}\".".format(self.idf.get("duplicates")))
+            self.errors.add("SC-E11")
 
         # Atlas IDF comment value checks
         for k, attribs in self.idf.items():

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -25,6 +25,8 @@ def simple_idf_parser(idf_file):
                 row_label = idf_row.pop(0)
                 if row_label in idf_dict:
                     idf_dict[row_label].extend(idf_row)
+                    # The single cell pipeline does not handle duplicated IDF fields, need to collect
+                    idf_dict["duplicates"] = row_label
                 else:
                     idf_dict[row_label] = idf_row
     return idf_dict

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -25,7 +25,7 @@ def simple_idf_parser(idf_file):
                 row_label = idf_row.pop(0)
                 if row_label in idf_dict:
                     idf_dict[row_label].extend(idf_row)
-                    # The single cell pipeline does not handle duplicated IDF fields, need to collect
+                    # The single cell pipeline does not handle duplicated IDF fields, need to collect here
                     idf_dict["duplicates"] = row_label
                 else:
                     idf_dict[row_label] = idf_row


### PR DESCRIPTION
The single cell pipeline's MAGE-TAB parser does not like duplicated IDF comments. Therefore we want to catch these at the parser stage and report as error in the single-cell check set. 
In addition to aggregating the values of duplicated fields, the parser now collects duplicated fields. This list is then used to report duplicated fields. 