### PR TITLE
Feature/retry uri check

### DIFF
--- a/atlas_metadata_validator/atlas_checker.py
+++ b/atlas_metadata_validator/atlas_checker.py
@@ -100,7 +100,7 @@ class AtlasMAGETABChecker:
                 executor.submit(is_valid_url, uris, logger)
                 future_to_url = {executor.submit(is_valid_url, uri, logger): uri for uri in uris}
                 for future in concurrent.futures.as_completed(future_to_url):
-                    if not future.result() is True:
+                    if future.result() is False:
                         logger.error("FASTQ_URI {} is not valid.".format(future_to_url[future]))
                         self.errors.add("GEN-E06")
 

--- a/atlas_metadata_validator/fetch.py
+++ b/atlas_metadata_validator/fetch.py
@@ -1,11 +1,10 @@
 
 import json
 import logging
-import os.path
-
 import pkg_resources
 import re
 import requests
+import time
 import urllib
 
 
@@ -38,7 +37,7 @@ def get_taxon(organism, logger=logging.getLogger()):
         return organism_lookup.get(organism)
 
 
-def is_valid_url(url, logger=None):
+def is_valid_url(url, logger=None, retry=3):
     """Check if a given URL exists without downloading the page/file
 
     For HTTP and HTTPS URLs, urllib.requests returns a http.client.HTTPResponse object,
@@ -49,7 +48,12 @@ def is_valid_url(url, logger=None):
         logger.debug("Checking {}... Done.".format(url))
         if r:
             return True
+
     except urllib.error.URLError:
+        logger.debug("URI check failed for {}. Retrying {} more times.".format(url, str(retry)))
+        if retry > 0:
+            time.sleep(5)
+            return is_valid_url(url, logger, retry-1)
         return False
 
 

--- a/atlas_metadata_validator/fetch.py
+++ b/atlas_metadata_validator/fetch.py
@@ -46,7 +46,7 @@ def is_valid_url(url, logger=None, retry=10):
     """
 
     # The global timeout for waiting for the response from the server before giving up
-    timeout = 1
+    timeout = 2
     socket.setdefaulttimeout(timeout)
 
     try:
@@ -57,7 +57,7 @@ def is_valid_url(url, logger=None, retry=10):
     except urllib.error.URLError:
         if retry > 0:
             logger.debug("URI check failed for {}. Retrying {} more time(s).".format(url, str(retry)))
-            time.sleep(30/retry)
+            time.sleep(60/retry)
             return is_valid_url(url, logger, retry-1)
         return False
 

--- a/atlas_metadata_validator/fetch.py
+++ b/atlas_metadata_validator/fetch.py
@@ -38,7 +38,7 @@ def get_taxon(organism, logger=logging.getLogger()):
         return organism_lookup.get(organism)
 
 
-def is_valid_url(url, logger=None, retry=5):
+def is_valid_url(url, logger=None, retry=10):
     """Check if a given URL exists without downloading the page/file
 
     For HTTP and HTTPS URLs, urllib.requests returns a http.client.HTTPResponse object,
@@ -57,7 +57,7 @@ def is_valid_url(url, logger=None, retry=5):
     except urllib.error.URLError:
         if retry > 0:
             logger.debug("URI check failed for {}. Retrying {} more time(s).".format(url, str(retry)))
-            time.sleep(3)
+            time.sleep(30/retry)
             return is_valid_url(url, logger, retry-1)
         return False
 


### PR DESCRIPTION
This improves the way the FASTQ URIs are validated. We've got a high number of false positives (URI was correct but the server was not responding properly and thus was reported as invalid).
I've added a number of re-tries for opening the connection currently set at 10 (with 5 I still got a few false errors). Between the retries the waiting time gets slightly longer. 
The second change is parallelising the tasks by first gathering all the URIs to check and then sending off the jobs in parallel. This very much improved the speed of the whole operation. The number of workers is currently set to 30 (which was determined based on testing on my local machine).