### PR TITLE
Special checks for HCA-imported experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ atlas_validation.py path/to/test.idf.txt
 - The script guesses the experiment type (sequencing, microarray or single-cell) from the MAGE-TAB. If this was unsuccessful the experiment type can be set by specifying the respective argument `-seq`, `-ma` or `-sc`. 
 - The data file and URI checks may take long time. Hence there is an option to skip these checks with `-x`.
 - Verbose logging can be activated with `-v`.
+- Special validation rules for HCA-imported experiments can be invoked with `-hca` option. The validator will otherwise guess if the experiment is an HCA import based on the HCAD accession code in the ExpressionAtlasAccession field. 

--- a/atlas_metadata_validator/atlas_validation_config.json
+++ b/atlas_metadata_validator/atlas_validation_config.json
@@ -33,7 +33,12 @@
   ],
   "optional_singlecell_idf_comments": [
     "EAAdditionalAttributes",
-    "EAExpectedClusters"
+    "EAExpectedClusters",
+    "HCALastUpdateDate"
+  ],
+    "required_idf_fields": [
+    "Experimental Factor Name",
+    "Protocol Name"
   ],
   "required_singlecell_sdrf_fields": [
     "material type",
@@ -45,16 +50,23 @@
     "library construction",
     "single cell isolation"
   ],
-  "required_droplet_sdrf_fields": [
+  "required_hca_sdrf_fields": [
+    "material type",
+    "library_layout",
+    "library_selection",
+    "library_source",
+    "library_strand",
+    "library construction",
+    "single cell isolation",
+    "HCA bundle UUID",
+    "HCA bundle version"
+  ],
+    "required_droplet_sdrf_fields": [
     "read1 file",
     "read2 file",
     "cdna read",
     "cell barcode read",
     "umi barcode read"
-  ],
-  "required_idf_fields": [
-    "Experimental Factor Name",
-    "Protocol Name"
   ],
   "ae_experiment_types": {
     "microarray": [

--- a/atlas_validation.py
+++ b/atlas_validation.py
@@ -23,6 +23,8 @@ def parse_args():
                         help="Path to the directory with SDRF and data files")
     parser.add_argument('-v', '--verbose', action='store_const', const=10, default=20,
                         help="Option to output detailed logging (debug level).")
+    parser.add_argument('-hca', action='store_true', default=False,
+                        help="Mark experiment as HCA import")
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument('-sc', '--singlecell', action='store_const', const="singlecell", dest='submission_type',
                        help="Force submission type to be 'singlecell'")
@@ -70,7 +72,9 @@ def main():
     else:
         logger.info("Setting submission type to \"{}\"".format(submission_type))
 
-    atlas_checker = AtlasMAGETABChecker(idf_file, sdrf_file_path, submission_type, skip_file_checks=args.skip_file_checks)
+    atlas_checker = AtlasMAGETABChecker(idf_file, sdrf_file_path, submission_type,
+                                        skip_file_checks=args.skip_file_checks,
+                                        is_hca=args.hca)
     atlas_checker.check_all(logger)
 
     # Collect error codes


### PR DESCRIPTION
We need to apply a few special rules for dealing with HCA-imported experiments because in some cases we won't have the raw data stored in ENA (but imported separately). 
I've modified the existing check for required SDRF fields to use a different list of fields for HCA imported experiments (which doesn't have FASTQ_URI but the HCA bundle fields).
If the experiment is HCA or not is determined based on the E-HCAD accession in the IDF or can be manually set with a -hca flag. 