### PR TITLE
File encoding check

### DIFF
--- a/atlas_metadata_validator/file.py
+++ b/atlas_metadata_validator/file.py
@@ -1,4 +1,4 @@
-
+import codecs
 import logging
 import os.path
 import sys
@@ -39,4 +39,19 @@ def file_exists(input_file, logger=None):
             logger.error(log_message)
         else:
             print(log_message)
-        sys.exit()
+        sys.exit(1)
+
+
+def is_utf8(input_file, logger=None):
+    """Check if the input file can be decoded using UTF-8 encoding and abort the program if not."""
+    try:
+        with codecs.open(input_file,  encoding='utf-8') as f:
+            f.read()
+
+    except UnicodeDecodeError:
+        log_message = "Input file {} is not in UTF-8 encoding.".format(input_file)
+        if logger:
+            logger.error(log_message)
+        else:
+            print("ERROR: " + log_message)
+        sys.exit(1)

--- a/atlas_metadata_validator/file.py
+++ b/atlas_metadata_validator/file.py
@@ -47,7 +47,6 @@ def is_utf8(input_file, logger=None):
     try:
         with codecs.open(input_file,  encoding='utf-8') as f:
             f.read()
-
     except UnicodeDecodeError:
         log_message = "Input file {} is not in UTF-8 encoding.".format(input_file)
         if logger:

--- a/atlas_metadata_validator/parser.py
+++ b/atlas_metadata_validator/parser.py
@@ -16,28 +16,22 @@ DEFAULT_DATA_DIRECTORY = "unpacked"
 def simple_idf_parser(idf_file):
     """Return an OrderedDict with IDF headers as keys and list of all values per key"""
 
-    try:
-        with codecs.open(idf_file, encoding='utf-8') as fi:
-            idf_raw = fi.readlines()
-
-            idf_dict = OrderedDict()
-            for row in idf_raw:
-                idf_row = row.rstrip('\n').split('\t')
-                # Skip empty lines and comments
-                characters = ''.join(idf_row).strip()
-                if not (len(characters) == 0 or characters.startswith('#')):
-                    row_label = idf_row.pop(0)
-                    if row_label in idf_dict:
-                        idf_dict[row_label].extend(idf_row)
-                        # The single cell pipeline does not handle duplicated IDF fields, need to collect here
-                        idf_dict["duplicates"] = row_label
-                    else:
-                        idf_dict[row_label] = idf_row
-        return idf_dict
-
-    except UnicodeDecodeError:
-        print("IDF is not in UTF-8 encoding.")
-        exit(1)
+    with codecs.open(idf_file, encoding='utf-8') as fi:
+        idf_raw = fi.readlines()
+        idf_dict = OrderedDict()
+        for row in idf_raw:
+            idf_row = row.rstrip('\n').split('\t')
+            # Skip empty lines and comments
+            characters = ''.join(idf_row).strip()
+            if not (len(characters) == 0 or characters.startswith('#')):
+                row_label = idf_row.pop(0)
+                if row_label in idf_dict:
+                    idf_dict[row_label].extend(idf_row)
+                    # The single cell pipeline does not handle duplicated IDF fields, need to collect here
+                    idf_dict["duplicates"] = row_label
+                else:
+                    idf_dict[row_label] = idf_row
+    return idf_dict
 
 
 def read_sdrf_file(sdrf_file):

--- a/atlas_metadata_validator/parser.py
+++ b/atlas_metadata_validator/parser.py
@@ -4,7 +4,6 @@ import os
 import re
 
 from collections import OrderedDict, defaultdict
-from sys import exit
 
 from atlas_metadata_validator.fetch import get_controlled_vocabulary
 from atlas_metadata_validator.file import file_exists, is_utf8

--- a/atlas_validation.py
+++ b/atlas_validation.py
@@ -8,7 +8,7 @@ import argparse
 import os
 import sys
 
-from atlas_metadata_validator.file import create_logger, file_exists
+from atlas_metadata_validator.file import create_logger, file_exists, is_utf8
 from atlas_metadata_validator.parser import get_sdrf_path, guess_submission_type_from_sdrf, guess_submission_type_from_idf, \
     read_sdrf_file, simple_idf_parser
 
@@ -44,8 +44,9 @@ def main():
     idf_file, data_dir, logging_level = args.idf, args.data_dir, args.verbose
     submission_type = args.submission_type
     
-    # Exit if IDF file doesn't exist
+    # Exit if IDF file doesn't exist or isn't in UTF-8 encoding
     file_exists(idf_file)
+    is_utf8(idf_file)
 
     # Create logger
     current_dir, idf_file_name = os.path.split(idf_file)


### PR DESCRIPTION
This feature adds a check of the encoding if the IDF and SDRF can be read with UTF-8 encoding before they are being opened for the downstream checks.
This is not an error like the other checks but does close the program if the files cannot be parsed correctly.  