### PR TITLE
Add 10xv3 to allowed library types

### DIFF
--- a/atlas_metadata_validator/atlas_checker.py
+++ b/atlas_metadata_validator/atlas_checker.py
@@ -45,7 +45,7 @@ class AtlasMAGETABChecker:
         if "technical replicate group" not in self.sdrf_comment_values:
             for s in self.sample2datafile:
                 if s.endswith("PAIRED") and len(self.sample2datafile[s]) > 2:
-                    logger.warn("Experiment is likely to contain technical replicates"
+                    logger.warn("Experiment is likely to contain technical replicates. "
                                 "Please add \"Comment[technical replicate group]\".")
                     break
                 elif not s.endswith("PAIRED") and len(self.sample2datafile[s]) > 1:

--- a/atlas_metadata_validator/atlas_validation_config.json
+++ b/atlas_metadata_validator/atlas_validation_config.json
@@ -1,10 +1,12 @@
 {
   "singlecell_library_construction": {
     "droplet": [
+      "10xv3",
       "10xv2",
       "drop-seq"
     ],
     "all": [
+      "10xv3",
       "10xv2",
       "drop-seq",
       "smart-seq2",


### PR DESCRIPTION
Standard 10xV3 library construction can be processed now. Added this to the list of allowed library types. 