### PR TITLE
Make HCA specific rules only based on -hca flag

### DIFF
--- a/atlas_metadata_validator/atlas_checker.py
+++ b/atlas_metadata_validator/atlas_checker.py
@@ -139,11 +139,6 @@ class AtlasMAGETABChecker:
                     if attrib and attrib.strip() not in get_controlled_vocabulary("singlecell_experiment_type", "atlas"):
                         logger.error("Unknown EAExperimentType: \"{}\"".format(attrib))
                         self.errors.add("SC-E04")
-            # Guess based on accession if it is an HCA experiment
-            elif re.search("ExpressionAtlasAccession", k, flags=re.IGNORECASE):
-                for attrib in attribs:
-                    if re.match(r"E-HCAD-\d+", attrib):
-                        self.is_hca = True
 
         # Required SDRF fields
         required_sdrf_names = get_controlled_vocabulary("required_singlecell_sdrf_fields", "atlas")


### PR DESCRIPTION
We also accept GEO experiments via HCA, these won't require the bundle info. 
So I'm removing the automatic guessing of the HCA status based on the experiment accession. 
The checks can still be triggered with the -hca flag, but the caveat is that they now cannot benautomatically run by the metadata repo CI when adding new experiments.  