### PR TITLE
Set env variable option to specify config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ export VALIDATION_CONFIG_FILE='atlas_validation_config.json'
 ```
 (if not specified the above values are used as default)
 
+Set local path where to store the validation config files, default is working dir when calling the script
+```bash
+export VALIDATION_CONFIG_LOCAL_PATH='/path/to/your/local/copy/'
+```
+
+
 ## Single-cell MAGE-TAB validator
 
 A MAGE-TAB pre-validation module for running checks that guarantee the experiment can be processed for [Single Cell Expression Atlas](https://www.ebi.ac.uk/gxa/sc/home). The checks are mainly covering the pre-validation by https://github.com/ebi-gene-expression-group/scxa-control-workflow/blob/master/bin/sdrfToNfConf.R in order to guarantee correct processing. It reads metadata directly from the MAGE-TAB and generates a log file in the directory of the IDF file.

--- a/atlas_metadata_validator/fetch.py
+++ b/atlas_metadata_validator/fetch.py
@@ -83,11 +83,12 @@ def get_controlled_vocabulary(category, resource="atlas", logger=None):
             config_file_name = os.environ.get("VALIDATION_CONFIG_FILE") or "atlas_validation_config.json"
             config_repo_name = os.path.basename(config_repo)
 
-            local_repo = os.path.join(os.getcwd(), config_repo_name)
+            local_config_path = os.environ.get("VALIDATION_CONFIG_LOCAL_PATH") or os.getcwd()
+            local_repo = os.path.join(local_config_path, config_repo_name)
             local_config = os.path.join(local_repo, config_file_name)
 
             if not os.path.exists(local_repo):
-                logger.debug("No local config found, cloning from remote repo {}".format(config_repo))
+                logger.debug("No local config found, cloning from remote repo {} to {}".format(config_repo, local_repo))
                 git.Repo.clone_from(config_repo, local_repo, branch="master")
 
             try:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atlas-metadata-validator",
-    version="1.4.0",
+    version="1.4.1",
     author="Anja Füllgrabe",
     author_email="anjaf@ebi.ac.uk",
     description="A MAGE-TAB validator for Expression Atlas and Single Cell Expression Atlas",


### PR DESCRIPTION
This change add the option to specify the path where to clone (or look up) the configuration file repository via an environment variable. The default setting is kept to be in the current working dir. 