### PR TITLE
Allow flexible URI SDRF fields

### DIFF
--- a/atlas_metadata_validator/atlas_checker.py
+++ b/atlas_metadata_validator/atlas_checker.py
@@ -93,7 +93,6 @@ class AtlasMAGETABChecker:
         if not self.skip_file_checks:
             logger.info("Checking FASTQ URIs. This may take a while... (Skip this check with -x option)")
             uri_fields = get_controlled_vocabulary("raw_data_download_sdrf_fields")
-            print(uri_fields)
             for uri_field in uri_fields:
                 uri_index = [i for i, c in enumerate(self.sdrf_header)
                              if re.search(uri_field, c, flags=re.IGNORECASE)]

--- a/atlas_metadata_validator/atlas_checker.py
+++ b/atlas_metadata_validator/atlas_checker.py
@@ -153,6 +153,17 @@ class AtlasMAGETABChecker:
                 logger.error("Required SDRF field \"{}\" not found.".format(field))
                 self.errors.add("SC-E05")
 
+        # Require at least one of those fields to be present
+        required_download_fields = get_controlled_vocabulary("raw_data_download_sdrf_fields", "atlas", logger)
+        found_download_field = False
+        for field in required_download_fields:
+            if field.lower() in self.sdrf_values or get_name(field) in self.header_dict:
+                found_download_field = True
+                break
+        if not found_download_field:
+            logger.error("Required data download SDRF field \"{}\" not found.".format(" or ".join(required_download_fields)))
+            self.errors.add("SC-E12")
+
         # Valid SDRF values
         library_construction_terms = get_controlled_vocabulary("singlecell_library_construction", "atlas", logger)
         sc_protocol_values = {}


### PR DESCRIPTION
Change the logic of the file checks to get a list of expected fields with download links from the config, instead of hard-coded "FASTQ_URI" field. This allows us more flexibility to use other fields too. 

A new check for the presence of either of the fields in the allowed list of raw data URIs was added. 

The change goes hand in hand with an update of the config file. 
https://github.com/ebi-gene-expression-group/metadata-validation-config/pull/1
