### PR TITLE
New single cell terms and file URI checks

### DIFF
--- a/atlas_metadata_validator/atlas_checker.py
+++ b/atlas_metadata_validator/atlas_checker.py
@@ -206,7 +206,7 @@ class AtlasMAGETABChecker:
                     logger.warn("Experiment contains more than 1 single cell library construction protocol.")
                 for protocol in sc_protocol_values:
                     if protocol.lower() not in library_construction_terms.get("all", []):
-                        logger.error("Library construction protocol is not supported for Expression Atlas."
+                        logger.error("Library construction protocol \"{}\" is not supported for Expression Atlas."
                                      .format(protocol))
                         self.errors.add("SC-E06")
             # Not all rows should be "not OK"


### PR DESCRIPTION
This update adds a few more checks to the file URI values:
- Checks that file URI values that are not a web address do not contain slashes or spaces
- Checks for duplicated values in the file URI columns, which are not allowed

For single-cell droplet experiments: New categories were added in the controlled vocabulary (imported from the config file) to make sure to only allow the specified values for the barcode reads comments. 
- The "size/offset" comments (-> "optional_droplet_numerical_fields") must be numerical
- The "read" comments (in "required_droplet_sdrf_fields") must match the controlled vocabulary (-> "allowed_read_values")