### PR TITLE
allow having no raw data for AnnData ingested experiments

### DIFF
--- a/atlas_metadata_validator/atlas_checker.py
+++ b/atlas_metadata_validator/atlas_checker.py
@@ -184,7 +184,7 @@ class AtlasMAGETABChecker:
 
         # Require at least one of those raw data fields to be present except for AnnData experiments
         if self.is_anndata:
-            logger.debug("Found AnnData ingested experiment, no raw data SDRF fields required")
+            logger.info("For AnnData ingestion, no raw data SDRF fields required")
         else:
             required_download_fields = get_controlled_vocabulary("raw_data_download_sdrf_fields", "atlas", logger)
             found_download_field = False

--- a/atlas_metadata_validator/atlas_checker.py
+++ b/atlas_metadata_validator/atlas_checker.py
@@ -90,7 +90,7 @@ class AtlasMAGETABChecker:
                 self.errors.add("GEN-E05")
 
         # FASTQ_URIs checks
-        if "E-ANND" in idf_file: # skip for E-ANND-x
+        if "E-ANND" in self.idf_file: # skip for E-ANND-x
             self.is_anndata = True
             logger.info("Skip FASTQ_URIs checks for AnnData experiments")
         else:
@@ -239,8 +239,11 @@ class AtlasMAGETABChecker:
                 allowed_read_values = get_controlled_vocabulary("allowed_read_values", "atlas", logger)
                 for dt in droplet_terms:
                     if dt not in self.sdrf_values:
-                        logger.error("Required SDRF droplet field \"{}\" not found.".format(dt))
-                        self.errors.add("SC-E10")
+                        if self.is_anndata:
+                            logger.warn("Required SDRF droplet field \"{}\" not found. This is optional for AnnData ingestion.".format(dt))
+                        else:
+                            logger.error("Required SDRF droplet field \"{}\" not found.".format(dt))
+                            self.errors.add("SC-E10")
                     else:
                         # Check that the values match the allowed
                         droplet_term_values = self.get_sdrf_values_for_field(dt, unique_only=True)


### PR DESCRIPTION
Update atlas metadata validator for AnnData ingestion:
- Skip raw data and FASTQ URI checks as they are not required.
- Allow no droplet fields if the ingested AnnData using droplet-based sequencing.